### PR TITLE
add ci and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Continuous Integration
+
+on:
+    pull_request:
+      branches: [main]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      with:
+        go-version: ^1.21
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 #v4.1.0
+
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -v ./...

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -37,6 +37,29 @@ func ParseSemver(version string) (Semver, error) {
 	return Semver{Major: major, Minor: minor, Patch: patch}, nil
 }
 
+func FindHighestPatchVersion(tags []string, version string) (string, error) {
+	var semverVersion Semver
+	for _, tag := range tags {
+
+		tagVersion, err := ParseSemver(tag)
+		if err != nil {
+			continue
+		}
+
+		if strings.Contains(version, ".") {
+			requestedMajorMinor := fmt.Sprintf("%d.%d", tagVersion.Major, tagVersion.Minor)
+			if requestedMajorMinor == version && tagVersion.Patch >= semverVersion.Patch {
+				semverVersion = tagVersion
+			}
+		} else {
+			if fmt.Sprintf("%d", tagVersion.Major) == version && tagVersion.Minor >= semverVersion.Minor {
+				semverVersion = tagVersion
+			}
+		}
+	}
+	return fmt.Sprintf("v%d.%d.%d", semverVersion.Major, semverVersion.Minor, semverVersion.Patch), nil
+}
+
 func ProcessActionsVersion(version string) string {
 	if strings.HasPrefix(version, "v") && !strings.Contains(version, ".") {
 		version = version + ".0."

--- a/pkg/version_test.go
+++ b/pkg/version_test.go
@@ -1,0 +1,55 @@
+package pkg
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected Semver
+		err      error
+	}{
+		{"v1.2.3", Semver{Major: 1, Minor: 2, Patch: 3}, nil},
+		{"v2.0.0", Semver{Major: 2, Minor: 0, Patch: 0}, nil},
+		{"v1.0.0-alpha", Semver{}, fmt.Errorf("invalid semver: v1.0.0-alpha")},
+		{"v1.2", Semver{}, fmt.Errorf("invalid semver: v1.2")},
+		{"v1.2.3.4", Semver{}, fmt.Errorf("invalid semver: v1.2.3.4")},
+	}
+
+	for _, test := range tests {
+		result, err := ParseSemver(test.version)
+		if err != nil && test.err == nil {
+			t.Errorf("Unexpected error for version %s: %v", test.version, err)
+		} else if err == nil && test.err != nil {
+			t.Errorf("Expected error for version %s: %v", test.version, test.err)
+		} else if result != test.expected {
+			t.Errorf("Unexpected result for version %s: got %v, want %v", test.version, result, test.expected)
+		}
+	}
+}
+
+func TestFindHighestPatchVersion(t *testing.T) {
+	tags := []string{"v1.2.3", "v2.0.0", "v1.0.0-alpha", "v1.2", "v1.3.1", "v3.5.0", "v3.4.0"}
+
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"1.2", "v1.2.3"},
+		{"2", "v2.0.0"},
+		{"1.3", "v1.3.1"},
+		{"1", "v1.3.1"},
+		{"3", "v3.5.0"},
+	}
+
+	for _, test := range tests {
+		result, err := FindHighestPatchVersion(tags, test.version)
+		if err != nil {
+			t.Errorf("Unexpected error for version %s: %v", test.version, err)
+		} else if result != test.expected {
+			t.Errorf("Unexpected result for version %s: got %s, want %s", test.version, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to improve code readability, error handling, and reusability. The most important changes involve modifying `cmd/root.go` to remove unnecessary code, handle version strings with or without a 'v' prefix, add an import statement for the "errors" package, and modify error messages. Additionally, a new function `FindHighestPatchVersion` is added to `pkg/version.go` to find the highest patch version for a given version, and a new GitHub Actions workflow file `ci.yml` is added for continuous integration. 

Main code changes:

* `cmd/root.go`: Removed unnecessary code, handled version strings with or without a 'v' prefix, added an import statement for the "errors" package, and modified error messages. (Fdee97a6)
* <a href="diffhunk://#diff-d95be69d99f869c321976c4aafcd2b082fbcf0be6b4effefe0d84d396bd66dc8R40-R62">`pkg/version.go`</a>: Added a new function `FindHighestPatchVersion` to find the highest patch version for a given version.

Continuous integration:

* <a href="diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R30">`.github/workflows/ci.yml`</a>: Added a new GitHub Actions workflow file `ci.yml` for continuous integration, triggered on pull requests to the main branch.

Testing improvements:

* <a href="diffhunk://#diff-63fc69a61b48c14615694535abd14c76a15b91c9043be55f46d289a35eebc6e0R1-R55">`pkg/version_test.go`</a>: Added new test cases for the `ParseSemver` and `FindHighestPatchVersion` functions to ensure correct functionality and handling of different input scenarios.