### PR TITLE
Add Branch Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ go.work
 
 /gh-pin-actions
 /gh-pin-actions.exe
+
+# pinned workflows
+*-pin.yml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
-            "args": ["-r", "actions/checkout" , "-v", "main"]
+            "args": ["-r", "actions/checkout" , "-v", "main", "--debug"]
         },
         {
             "name": "Debug sending Major.Minor",
@@ -18,7 +18,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
-            "args": ["-r", "actions/checkout" , "-v", "3.5"]
+            "args": ["-r", "actions/checkout" , "-v", "3.5", "--debug"]
         },
         {
             "name": "Debug sending Major",
@@ -26,7 +26,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
-            "args": ["-r", "actions/checkout" , "-v", "3"]
+            "args": ["-r", "actions/checkout" , "-v", "3", "--debug"]
         },
         {
             "name": "Debug sending Major.Minor.Patch ",
@@ -34,7 +34,15 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
-            "args": ["-r", "actions/checkout" , "-v", "3.5.3"]
+            "args": ["-r", "actions/checkout" , "-v", "3.5.3", "--debug"]
+        },
+        {
+            "name": "Debug sending Major.Minor.Patch ",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": ["workflows", "--debug"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Branch sent as version",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": ["-r", "actions/checkout" , "-v", "main"]
+        },
+        {
+            "name": "Debug sending Major.Minor",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": ["-r", "actions/checkout" , "-v", "3.5"]
+        },
+        {
+            "name": "Debug sending Major",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": ["-r", "actions/checkout" , "-v", "3"]
+        },
+        {
+            "name": "Debug sending Major.Minor.Patch ",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": ["-r", "actions/checkout" , "-v", "3.5.3"]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 `gh-pin-actions` is a GitHub CLI extension that allows you to pin GitHub Actions based on their version.
 
-Currently supported formats: `<repo>/<action>@<version>`
+Currently supported formats:
+
+- `<repo>/<action>@<version>`
+- `<repos>/<action>@<branchName>`
 
 ## Installation
 
@@ -44,6 +47,10 @@ Example:
 
 ```sh
 gh pin-actions -r actions/checkout -v 3
+```
+
+```sh
+gh pin-actions -r actions/checkout -b main
 ```
 
 ### GitHub Actions Workflows

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -60,7 +60,7 @@ func FindHighestPatchVersion(tags []string, version string) (string, error) {
 	return fmt.Sprintf("v%d.%d.%d", semverVersion.Major, semverVersion.Minor, semverVersion.Patch), nil
 }
 
-func ProcessActionsVersion(version string) string {
+func FormatVersion(version string) string {
 	if strings.HasPrefix(version, "v") && !strings.Contains(version, ".") {
 		version = version + ".0."
 	}


### PR DESCRIPTION
This pull request primarily introduces the ability to pin GitHub Actions based on branch names, in addition to the existing functionality of pinning based on version numbers.

The main changes are as follows:

Updates to command-line interface:

* <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR35">`cmd/root.go`</a>: Added a new flag `branchName` to the command-line interface to accept branch names. The `ActionsPin` function was updated to handle branch names and versions differently. If a branch name is provided, the `GetBranchHash` function is called to get the commit hash of the branch. If a version is provided, it's checked for validity and then the `GetActionHashByVersion` function is called as before. <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR35">[1]</a> <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL60-R92">[2]</a>

New functions:

* <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR160-R170">`cmd/root.go`</a>: Added a new function `GetBranchHash` that takes a repository and a branch name as input and returns the commit hash of the branch. This function is used to get the commit hash when a branch name is provided.
* <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR188-R217">`cmd/workflows.go`</a>: Added two new functions `processActionWithVersion` and `processActionWithBranch` to handle actions with versions and branches respectively. These functions are used in `processActionsYaml` to process each step of a job.

Updates to README:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R8">`README.md`</a>: Updated the supported formats to include `<repos>/<action>@<branchName>`. Added an example of using the new branch name functionality. <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R8">[1]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R55">[2]</a>

Other notable changes:

* <a href="diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R1-R48">`.vscode/launch.json`</a>: Added configurations for debugging different version formats.
* <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR108-R147">`cmd/workflows.go`</a>: Updated `processActionsYaml` to handle actions with hashes, versions, and branches differently. If an action already has a hash, it's left as is. If it has a version, `processActionWithVersion` is called. If it has a branch, `processActionWithBranch` is called.
* <a href="diffhunk://#diff-d95be69d99f869c321976c4aafcd2b082fbcf0be6b4effefe0d84d396bd66dc8L63-R63">`pkg/version.go`</a>: Renamed `ProcessActionsVersion` to `FormatVersion` to better reflect its functionality.