### PR TITLE
refactor actions string processing

### DIFF
--- a/cmd/workflows.go
+++ b/cmd/workflows.go
@@ -111,10 +111,6 @@ func processActionsYaml(workflow string) {
 	if err != nil {
 		logger.Warn("Error compiling Hash regex", logger.Args("error:", err))
 	}
-	branchRegex, err := regexp.Compile(`^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+$`)
-	if err != nil {
-		logger.Warn("Error compiling branch regex", logger.Args("error:", err))
-	}
 
 	// Loop through all the jobs and steps
 	for _, job := range wf.Jobs {
@@ -125,26 +121,13 @@ func processActionsYaml(workflow string) {
 					// Action already has a hash
 					logger.Info("Action already has a hash", logger.Args("action:", action))
 					continue
-				} else if strings.Contains(action, "@v") {
-					// Action has a version
-					actionWithVersion := action
-					actionWithSha, err := processActionWithVersion(actionWithVersion)
+				} else {
+					// Actions doesn't have a hash
+					actionWithSha, err := processAction(action)
 					if err != nil {
-						logger.Error("Error getting commit sha for action", logger.Args("action:", actionWithVersion, "error:", err))
 						logger.Warn("Nothing will be updated")
-						actionWithSha = actionWithVersion
 					}
-					writeModifiedWorkflowToFile(pinnedWorkflow, actionWithVersion, actionWithSha)
-				} else if branchRegex.MatchString(action) {
-					// Action has a branch
-					actionWithBranch := action
-					actionWithSha, err := processActionWithBranch(actionWithBranch)
-					if err != nil {
-						logger.Error("Error getting commit sha for action with Branch", logger.Args("action:", actionWithBranch, "error:", err))
-						logger.Warn("Nothing will be updated")
-						actionWithSha = actionWithBranch
-					}
-					writeModifiedWorkflowToFile(pinnedWorkflow, actionWithBranch, actionWithSha)
+					writeModifiedWorkflowToFile(pinnedWorkflow, action, actionWithSha)
 				}
 			}
 		}
@@ -156,7 +139,9 @@ func processActionsYaml(workflow string) {
 }
 
 func writeModifiedWorkflowToFile(fileName string, action string, actionWithSha string) {
-
+	if action == "" || actionWithSha == "" {
+		logger.Error("action or actionWithSha are empty", logger.Args("action:", action, "actionWithSha:", actionWithSha))
+	}
 	newFileContent, err := os.ReadFile(fileName)
 	if err != nil {
 		logger.Warn("Error reading file", logger.Args("file:", fileName, "error:", err))
@@ -214,4 +199,35 @@ func processActionWithBranch(actionWithBranch string) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%s@%s #%s", repoWithOwner, strings.TrimSpace(commitSha), strings.TrimSpace(branchName)), nil
+}
+
+func processAction(action string) (string, error) {
+	var actionWithSha string
+	branchRegex, err := regexp.Compile(`^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+$`)
+	if err != nil {
+		logger.Warn("Error compiling branch regex", logger.Args("error:", err))
+	}
+	if strings.Contains(action, "@v") {
+		// Action has a version
+		actionWithVersion := action
+		actionWithSha, err = processActionWithVersion(actionWithVersion)
+		if err != nil {
+			logger.Error("Error getting commit sha for action", logger.Args("action:", actionWithVersion, "error:", err))
+			//logger.Warn("Nothing will be updated")
+			actionWithSha = actionWithVersion
+			return actionWithSha, err
+		}
+
+	} else if branchRegex.MatchString(action) {
+		// Action has a branch
+		actionWithBranch := action
+		actionWithSha, err = processActionWithBranch(actionWithBranch)
+		if err != nil {
+			logger.Error("Error getting commit sha for action with Branch", logger.Args("action:", actionWithBranch, "error:", err))
+			logger.Warn("Nothing will be updated")
+			actionWithSha = actionWithBranch
+			return actionWithSha, err
+		}
+	}
+	return actionWithSha, nil
 }

--- a/cmd/workflows.go
+++ b/cmd/workflows.go
@@ -209,7 +209,6 @@ func processAction(action string) (string, error) {
 		actionWithSha, err = processActionWithVersion(actionWithVersion)
 		if err != nil {
 			logger.Error("Error getting commit sha for action", logger.Args("action:", actionWithVersion, "error:", err))
-			//logger.Warn("Nothing will be updated")
 			actionWithSha = actionWithVersion
 			return actionWithSha, err
 		}
@@ -220,7 +219,6 @@ func processAction(action string) (string, error) {
 		actionWithSha, err = processActionWithBranch(actionWithBranch)
 		if err != nil {
 			logger.Error("Error getting commit sha for action with Branch", logger.Args("action:", actionWithBranch, "error:", err))
-			logger.Warn("Nothing will be updated")
 			actionWithSha = actionWithBranch
 			return actionWithSha, err
 		}

--- a/cmd/workflows.go
+++ b/cmd/workflows.go
@@ -172,12 +172,10 @@ func createTempYAMLFile(fileName string) (string, error) {
 }
 
 func processActionWithVersion(actionWithVersion string) (string, error) {
-	actionSplit := strings.Split(actionWithVersion, "@v")
-	if len(actionSplit) < 2 {
-		return "", fmt.Errorf("invalid action format: %s", actionWithVersion)
+	repoWithOwner, versionParsed, err := pkg.SplitActionString(actionWithVersion, "@v")
+	if err != nil {
+		return "", err
 	}
-	repoWithOwner := actionSplit[0]
-	versionParsed := actionSplit[1]
 	actionVersion := pkg.FormatVersion(versionParsed)
 	commitSha, tagVersion, err := GetActionHashByVersion(repoWithOwner, actionVersion)
 	if err != nil {
@@ -188,12 +186,10 @@ func processActionWithVersion(actionWithVersion string) (string, error) {
 }
 
 func processActionWithBranch(actionWithBranch string) (string, error) {
-	actionSplit := strings.Split(actionWithBranch, "@")
-	if len(actionSplit) < 2 {
-		return "", fmt.Errorf("invalid action format: %s", actionWithBranch)
+	repoWithOwner, branchName, err := pkg.SplitActionString(actionWithBranch, "@")
+	if err != nil {
+		return "", err
 	}
-	repoWithOwner := actionSplit[0]
-	branchName := actionSplit[1]
 	commitSha, err := GetBranchHash(repoWithOwner, branchName)
 	if err != nil {
 		return "", err

--- a/pkg/action_utils.go
+++ b/pkg/action_utils.go
@@ -1,0 +1,16 @@
+package pkg
+
+import (
+	"fmt"
+	"strings"
+)
+
+func SplitActionString(action string, delimiter string) (string, string, error) {
+	actionSplit := strings.Split(action, delimiter)
+	if len(actionSplit) < 2 {
+		return "", "", fmt.Errorf("invalid action format: %s", action)
+	}
+	repoWithOwner := actionSplit[0]
+	branchOrVersion := actionSplit[1]
+	return repoWithOwner, branchOrVersion, nil
+}

--- a/pkg/action_utils_test.go
+++ b/pkg/action_utils_test.go
@@ -1,0 +1,33 @@
+package pkg
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSplitActionString(t *testing.T) {
+	tests := []struct {
+		action      string
+		delimiter   string
+		expected1   string
+		expected2   string
+		expectedErr error
+	}{
+		{"owner/repo@v3", "@v", "owner/repo", "3", nil},
+		{"owner/repo@main", "@", "owner/repo", "main", nil},
+		{"owner/repo@v3.3.3", "@v", "owner/repo", "3.3.3", nil},
+		{"repo", "/", "", "", fmt.Errorf("invalid action format: repo")},
+		{"repo", "|", "", "", fmt.Errorf("invalid action format: repo")},
+	}
+
+	for _, test := range tests {
+		result1, result2, err := SplitActionString(test.action, test.delimiter)
+		if err != nil && test.expectedErr == nil {
+			t.Errorf("Unexpected error for action %s: %v", test.action, err)
+		} else if err == nil && test.expectedErr != nil {
+			t.Errorf("Expected error for action %s: %v", test.action, test.expectedErr)
+		} else if result1 != test.expected1 || result2 != test.expected2 {
+			t.Errorf("Unexpected result for action %s: got (%s, %s), want (%s, %s)", test.action, result1, result2, test.expected1, test.expected2)
+		}
+	}
+}


### PR DESCRIPTION
This pull request primarily refactors the `processActionsYaml` function in `cmd/workflows.go` to simplify the handling of different types of actions. It also introduces a new utility function `SplitActionString` in a new file `pkg/action_utils.go` to split an action string into its components. The changes enhance the readability and maintainability of the code.

Here are the key changes:

Refactoring and Error Handling:

* <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL114-L117">`cmd/workflows.go`</a>: The `processActionsYaml` function has been significantly refactored. The branch regex compilation is removed from the main function and moved to a new function `processAction`. The handling of actions with a version, branch, or neither has been moved to `processAction`. This function is now called in the else block of the loop through jobs and steps, simplifying the logic in `processActionsYaml`. <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL114-L117">[1]</a> <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL128-R130">[2]</a>
* <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL159-R144">`cmd/workflows.go`</a>: Added error handling in `writeModifiedWorkflowToFile` to check if `action` or `actionWithSha` are empty.

Improvements in Action Processing:

* <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL190-L195">`cmd/workflows.go`</a>: The `processActionWithVersion` and `processActionWithBranch` functions now use the new utility function `pkg.SplitActionString` to split the action string into its components, improving code reuse. <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL190-L195">[1]</a> <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL206-R227">[2]</a>
* <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL206-R227">`cmd/workflows.go`</a>: Introduced a new function `processAction` that determines the type of action and processes it accordingly. This function uses `processActionWithVersion` and `processActionWithBranch` for actions with a version or branch respectively.

New Utility Function and Tests:

* <a href="diffhunk://#diff-02dfffe696b133baf05c7232b75f037917da321324a720f9a63d19493bf46727R1-R16">`pkg/action_utils.go`</a>: Introduced a new utility function `SplitActionString` that splits an action string into its components.
* <a href="diffhunk://#diff-e83d499984809493e30a20f50ef7f1b4ef71d0f8b8526f5d0e9c3a4019325243R1-R33">`pkg/action_utils_test.go`</a>: Added tests for the new utility function `SplitActionString`.