### PR TITLE
sort tags in desc order, add ability to process sub-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Currently supported formats:
 
 - `<repo>/<action>@<version>`
 - `<repos>/<action>@<branchName>`
+- `<repo>/<action>/sub-action@<version>`
+- `<repo>/<action>/sub-action@<branchName>`
 
 ## Installation
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func GetActionHashByVersion(repository string, version string) (string, string, 
 	var tagVersion string
 	var std_err bytes.Buffer
 	var err error
-
+	repository = pkg.ExtractOwnerRepo(repository)
 	// Remove 'v' from the version string if sent through command line
 	version = strings.TrimPrefix(version, "v")
 	// Check to see if value received is latest version or a specific version
@@ -159,6 +159,7 @@ func GetLatestPatchVersion(repository string, version string) (string, error) {
 }
 
 func GetBranchHash(repository string, branch string) (string, error) {
+	repository = pkg.ExtractOwnerRepo(repository)
 	cliArgs := ".commit.sha"
 	cliOptions := fmt.Sprintf("repos/%s/branches/%s", repository, branch)
 	shaCommit, std_err, err := gh.Exec("api", cliOptions, "--jq", cliArgs)

--- a/pkg/action_utils.go
+++ b/pkg/action_utils.go
@@ -14,3 +14,13 @@ func SplitActionString(action string, delimiter string) (string, string, error) 
 	branchOrVersion := actionSplit[1]
 	return repoWithOwner, branchOrVersion, nil
 }
+
+func ExtractOwnerRepo(repository string) string {
+	if strings.Count(repository, "/") > 1 {
+		parts := strings.Split(repository, "/")
+		if len(parts) > 2 {
+			repository = parts[0] + "/" + parts[1]
+		}
+	}
+	return repository
+}

--- a/pkg/action_utils_test.go
+++ b/pkg/action_utils_test.go
@@ -31,3 +31,22 @@ func TestSplitActionString(t *testing.T) {
 		}
 	}
 }
+func TestExtractOwnerRepo(t *testing.T) {
+	tests := []struct {
+		repository string
+		expected   string
+	}{
+		{"owner/repo", "owner/repo"},
+		{"owner/repo/sub", "owner/repo"},
+		{"owner/repo/sub/sub", "owner/repo"},
+		{"repo", "repo"},
+		{"", ""},
+	}
+
+	for _, test := range tests {
+		result := ExtractOwnerRepo(test.repository)
+		if result != test.expected {
+			t.Errorf("Unexpected result for repository %s: got %s, want %s", test.repository, result, test.expected)
+		}
+	}
+}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -39,6 +40,17 @@ func ParseSemver(version string) (Semver, error) {
 
 func FindHighestPatchVersion(tags []string, version string) (string, error) {
 	var semverVersion Semver
+	// Remove the last element if it's an empty string
+	if tags[len(tags)-1] == "" {
+		tags = tags[:len(tags)-1]
+	}
+
+	//sort tags in descending order
+	sort.Strings(tags)
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i] > tags[j]
+	})
+
 	for _, tag := range tags {
 
 		tagVersion, err := ParseSemver(tag)
@@ -48,12 +60,14 @@ func FindHighestPatchVersion(tags []string, version string) (string, error) {
 
 		if strings.Contains(version, ".") {
 			requestedMajorMinor := fmt.Sprintf("%d.%d", tagVersion.Major, tagVersion.Minor)
-			if requestedMajorMinor == version && tagVersion.Patch >= semverVersion.Patch {
+			if requestedMajorMinor == version {
 				semverVersion = tagVersion
+				break
 			}
 		} else {
-			if fmt.Sprintf("%d", tagVersion.Major) == version && tagVersion.Minor >= semverVersion.Minor {
+			if fmt.Sprintf("%d", tagVersion.Major) == version {
 				semverVersion = tagVersion
+				break
 			}
 		}
 	}

--- a/pkg/version_test.go
+++ b/pkg/version_test.go
@@ -31,7 +31,7 @@ func TestParseSemver(t *testing.T) {
 }
 
 func TestFindHighestPatchVersion(t *testing.T) {
-	tags := []string{"v1.2.3", "v2.0.0", "v1.0.0-alpha", "v1.2", "v1.3.1", "v3.5.0", "v3.4.0"}
+	tags := []string{"v1.2.3", "v2.0.0", "v1.0.0-alpha", "v1.2", "v1.3.1", "v3.5.0", "v3.4.0", "v3.5.2", "v3.5.1"}
 
 	tests := []struct {
 		version  string
@@ -41,7 +41,7 @@ func TestFindHighestPatchVersion(t *testing.T) {
 		{"2", "v2.0.0"},
 		{"1.3", "v1.3.1"},
 		{"1", "v1.3.1"},
-		{"3", "v3.5.0"},
+		{"3", "v3.5.2"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pull request includes changes to support sub-actions in repository references, improve repository parsing, and enhance version handling. The most important changes are the addition of sub-action support and the optimization of the `FindHighestPatchVersion` function to find the highest patch version more efficiently.

Support for sub-actions and repository parsing:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R10">`README.md`</a>: The supported formats have been updated to include sub-actions in repository references.
* <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL107-R107">`cmd/root.go`</a>: The `GetActionHashByVersion` and `GetLatestPatchVersion` functions now use the `pkg.ExtractOwnerRepo` function to parse the repository string. <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL107-R107">[1]</a> <a href="diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR162">[2]</a>

Enhancements to version handling:

* <a href="diffhunk://#diff-d95be69d99f869c321976c4aafcd2b082fbcf0be6b4effefe0d84d396bd66dc8R5">`pkg/version.go`</a>: The `FindHighestPatchVersion` function has been optimized to find the highest patch version more efficiently. It now sorts the tags in descending order, and breaks the loop as soon as it finds the highest patch version. <a href="diffhunk://#diff-d95be69d99f869c321976c4aafcd2b082fbcf0be6b4effefe0d84d396bd66dc8R43-R53">[1]</a> <a href="diffhunk://#diff-d95be69d99f869c321976c4aafcd2b082fbcf0be6b4effefe0d84d396bd66dc8L51-R70">[2]</a>