### PR TITLE
Add overwrite workflow flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Usage:
   gh workflows [flags]
 
 Flags:
-  -h, --help   help for workflows
+  -h, --help        help for workflows
+  -o, --overwrite   overwrite existing workflow files
 
 Global Flags:
   -d, --debug   debug mode - set logger to debug level
@@ -79,7 +80,7 @@ gh pin-actions workflows
 ```
 
 >**Note**
->Currently `gh pin-actions` will create a new file within your `.github/workflows` directory with the suffix `-pin`. This is to ensure that you can review the changes before committing them to your repository. Once you have reviewed the changes, you can delete the original workflow file and rename the `-pin` file to the original workflow file name.
+>`gh pin-actions` will create a new file within your `.github/workflows` directory with the suffix `-pin`. This is to ensure that you can review the changes before committing them to your repository. Once you have reviewed the changes, you can then pass the `--overwrite` flag to overwrite your existing workflow files with the pin shas.
 
 ## Contributing
 

--- a/cmd/workflows.go
+++ b/cmd/workflows.go
@@ -23,7 +23,8 @@ var (
 		action with version in the workflow file and replaces it with the sha of the specific version`,
 		Run: processWorkflows,
 	}
-	logger *pterm.Logger
+	logger             *pterm.Logger
+	overwriteWorkflows bool
 )
 
 type Step struct {
@@ -44,7 +45,7 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	// rootCmd.Flags().StringVarP(&repository, "repository", "r", "", "repository in the owner/repo format")
+	workflowsCmd.Flags().BoolVarP(&overwriteWorkflows, "overwrite", "o", false, "overwrite existing workflow files")
 	// rootCmd.MarkFlagRequired("repository")
 
 	// rootCmd.Flags().StringVarP(&version, "version", "v", "latest", "version of the tag to pin to (ex. 3; 3.1; 3.1.1)")
@@ -131,6 +132,13 @@ func processActionsYaml(workflow string) {
 				}
 			}
 		}
+	}
+	if overwriteWorkflows {
+		err := os.Rename(pinnedWorkflow, workflow)
+		if err != nil {
+			logger.Warn("Error renaming file", logger.Args("file:", pinnedWorkflow, "error:", err))
+		}
+		pinnedWorkflow = workflow
 	}
 	if err == nil {
 		fmt.Println("Done! Please review the changes in the following file:", pinnedWorkflow)


### PR DESCRIPTION
This pull request primarily focuses on the addition of a new `--overwrite` flag in the `gh pin-actions workflows` command. This flag allows the user to overwrite existing workflow files directly, simplifying the process of applying changes.

Addition of the `--overwrite` flag:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R83">`README.md`</a>: Updated the description of `gh pin-actions workflows` to explain the new `--overwrite` flag functionality.
* <a href="diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR136-R142">`cmd/workflows.go`</a>: Updated the `processActionsYaml` function to rename the pinned workflow file to the original workflow file if the `--overwrite` flag is used.