### PR TITLE
add release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER) 🚢'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,7 +42,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@bb2d833b08b6c288608686672b93a8a4589cdc49 #v4.9.7
         env:
           VALIDATE_ALL_CODEBASE: false
           # Change to 'master' if your main branch differs
@@ -51,11 +51,11 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_GO: false
       - name: Lint Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
         with:
            go-version: '1.21'
            cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc #v3.7.0
         with:
             version: v1.54

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter Update
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes updates to the release drafter configuration and the linter workflow. The most important changes include the addition of a new release drafter configuration, updates to the linter workflow to use specific commit hashes for actions, and the addition of a new workflow for updating the release draft.

Updates to release drafter configuration:

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR1-R33): Added a new release drafter configuration file with templates for naming, tagging, and categorizing changes.

Changes to linter workflow:

* [`.github/workflows/linter.yml`](diffhunk://#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L45-R45): Updated the linter workflow to use specific commit hashes for `super-linter`, `setup-go`, and `golangci-lint-action` to ensure consistent versions. [[1]](diffhunk://#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L45-R45) [[2]](diffhunk://#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L54-R59)

Creation of new workflow:

* [`.github/workflows/release-drafter.yml`](diffhunk://#diff-6942706d71f70018c8f087d0a45e76d7192106920b2b3892cb86f70443ec2078R1-R18): Added a new workflow for updating the release drafter on pushes to the main branch, excluding certain paths.