### PR TITLE
fix: check for local action reference

### DIFF
--- a/cmd/workflows.go
+++ b/cmd/workflows.go
@@ -230,6 +230,10 @@ func processAction(action string) (string, error) {
 			actionWithSha = actionWithBranch
 			return actionWithSha, err
 		}
+	} else if strings.Contains(action, "./") {
+		// Action is local
+		logger.Info("Action is local", logger.Args("action:", action))
+		return action, nil
 	}
 	return actionWithSha, nil
 }

--- a/cmd/workflows_test.go
+++ b/cmd/workflows_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetWorkflowFiles(t *testing.T) {
+	// Setup: create a temporary directory with test files
+	tempDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tempDir, ".github", "workflows"), 0755)
+	testFiles := []string{
+		"workflow1.yml",
+		"workflow2.yaml",
+		"workflow-pin.yml",
+		"workflow-pin.yaml",
+	}
+	for _, file := range testFiles {
+		os.WriteFile(filepath.Join(tempDir, ".github", "workflows", file), []byte{}, 0644)
+	}
+
+	// Override the directory for testing
+	originalDir, _ := os.Getwd()
+	defer func() { os.Chdir(originalDir) }()
+	os.Chdir(tempDir)
+
+	workflowFiles, err := getWorkflowFiles()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expectedFiles := []string{
+		filepath.Join(".github", "workflows", "workflow1.yml"),
+		filepath.Join(".github", "workflows", "workflow2.yaml"),
+	}
+
+	if len(workflowFiles) != len(expectedFiles) {
+		t.Errorf("Expected %d workflow files, got %d", len(expectedFiles), len(workflowFiles))
+	}
+
+	for _, expected := range expectedFiles {
+		found := false
+		for _, actual := range workflowFiles {
+			if strings.HasSuffix(actual, expected) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected file %s not found", expected)
+		}
+	}
+}
+
+func TestCreateTempYAMLFile(t *testing.T) {
+	// Setup: create a temporary file
+	tempFile, err := os.CreateTemp("", "tempfile")
+	if err != nil {
+		t.Fatalf("Unexpected error creating temp file: %v", err)
+	}
+	defer tempFile.Close()
+
+	content := []byte("test content")
+	if _, err := tempFile.Write(content); err != nil {
+		t.Fatalf("Unexpected error writing to temp file: %v", err)
+	}
+
+	tempFileName := tempFile.Name()
+	newFileName, err := createTempYAMLFile(tempFileName)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !strings.HasSuffix(newFileName, "-pin.yml") {
+		t.Errorf("Expected new file name to end with '-pin.yml', got %s", newFileName)
+	}
+
+	newContent, err := os.ReadFile(newFileName)
+	if err != nil {
+		t.Fatalf("Unexpected error reading new file: %v", err)
+	}
+
+	if string(newContent) != string(content) {
+		t.Errorf("Expected content %s, got %s", string(content), string(newContent))
+	}
+}

--- a/cmd/workflows_test.go
+++ b/cmd/workflows_test.go
@@ -10,7 +10,10 @@ import (
 func TestGetWorkflowFiles(t *testing.T) {
 	// Setup: create a temporary directory with test files
 	tempDir := t.TempDir()
-	os.MkdirAll(filepath.Join(tempDir, ".github", "workflows"), 0755)
+	err := os.MkdirAll(filepath.Join(tempDir, ".github", "workflows"), 0755)
+	if err != nil {
+		t.Fatalf("Unexpected error creating directory: %v", err)
+	}
 	testFiles := []string{
 		"workflow1.yml",
 		"workflow2.yaml",
@@ -18,13 +21,24 @@ func TestGetWorkflowFiles(t *testing.T) {
 		"workflow-pin.yaml",
 	}
 	for _, file := range testFiles {
-		os.WriteFile(filepath.Join(tempDir, ".github", "workflows", file), []byte{}, 0644)
+		err := os.WriteFile(filepath.Join(tempDir, ".github", "workflows", file), []byte{}, 0644)
+		if err != nil {
+			t.Fatalf("Unexpected error writing file: %v", err)
+		}
 	}
 
 	// Override the directory for testing
 	originalDir, _ := os.Getwd()
-	defer func() { os.Chdir(originalDir) }()
-	os.Chdir(tempDir)
+	defer func() {
+		err := os.Chdir(originalDir)
+		if err != nil {
+			t.Fatalf("Unexpected error changing directory: %v", err)
+		}
+	}()
+	err = os.Chdir(tempDir)
+	if err != nil {
+		t.Fatalf("Unexpected error changing directory: %v", err)
+	}
 
 	workflowFiles, err := getWorkflowFiles()
 	if err != nil {


### PR DESCRIPTION
This pull request includes changes to handle local actions in the `processAction` function and adds new tests for workflow file handling. The most important changes include updating the `processAction` function to recognize local actions and adding comprehensive tests for workflow file processing.

Enhancements to workflow handling:

* [`cmd/workflows.go`](diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR233-R236): Modified the `processAction` function to handle local actions by checking if the action contains "./" and logging a message if it is local.

Addition of tests:

* [`cmd/workflows_test.go`](diffhunk://#diff-4d2146ac99cf7b728f8adcb45a11f2404b7fdf0100bf9fecdcfe471dfe16e960R1-R88): Added new tests for `getWorkflowFiles` to verify the retrieval of workflow files from a temporary directory and for `createTempYAMLFile` to ensure the correct creation and content of temporary YAML files.

fixes #9 