### PR TITLE
chore: update gh-extension-precompile to v2.0.0 and adjust go_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
       branches: [main]
 
+permissions:
+  contents: read # Allow the workflow to read the repository contents
+
 jobs:
 
   build:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,6 +18,9 @@ name: Source Linter
 on:
   pull_request:
     branches: [master, main]
+
+permissions:
+  contents: read # Allow the workflow to read the repository contents
     
 ###############
 # Set the Job #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
-      - uses: cli/gh-extension-precompile@b0da21c1042c79394bfb66a6c320bb1e360b876a #v1.4.0
+      - uses: cli/gh-extension-precompile@561b19deda1228a0edf856c3325df87416f8c9bd #v2.0.0
         with:
-          go_version: "1.21"
+          go_version_file: go.mod


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a newer version of the `gh-extension-precompile` action and modifies how the Go version is specified.

Key changes in GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R17): Updated the `gh-extension-precompile` action from version `v1.4.0` to `v2.0.0`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R17): Changed the `go_version` configuration to use the `go.mod` file for determining the Go version.