### PR TITLE
new `--latest` flag to the `workflows` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
       with:
-        go-version: ^1.21
+        go-version-file: go.mod
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 #v4.1.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Get dependencies
       run: go get -v -t -d ./...

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,13 +39,13 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       ################################
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter/slim@bb2d833b08b6c288608686672b93a8a4589cdc49 #v4.9.7
+        uses: github/super-linter/slim@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 #v7
         env:
           VALIDATE_ALL_CODEBASE: false
           # Change to 'master' if your main branch differs
@@ -54,11 +54,11 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_GO: false
       - name: Lint Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
            go-version: '1.21'
            cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc #v3.7.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 #v9.2.0
         with:
             version: v1.54

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 #v7.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
-      - uses: cli/gh-extension-precompile@561b19deda1228a0edf856c3325df87416f8c9bd #v2.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - uses: cli/gh-extension-precompile@9e2237c30f869ad3bcaed6a4be2cd43564dd421b #v2.1.0
         with:
           go_version_file: go.mod

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Usage:
 
 Flags:
   -h, --help        help for workflows
+      --latest      resolve external version refs to the latest stable release before pinning
   -o, --overwrite   overwrite existing workflow files
 
 Global Flags:
@@ -77,6 +78,32 @@ Example:
 
 ```sh
 gh pin-actions workflows
+```
+
+When `--latest` is enabled:
+
+- Version refs (for example `actions/checkout@v4`) resolve to the latest stable release for that action before pinning.
+- SHA-pinned external refs ignore the current SHA and resolve `latest` from the base `owner/repo`.
+- The full action subpath is preserved when repinning (for example `owner/repo/path/to/action@...` stays `owner/repo/path/to/action@...`).
+- Branch refs keep branch semantics and pin the branch head (`#main`, `#release/v1.2`, etc.).
+- Local (`./...`) and unsupported refs (for example `docker://...`) are left unchanged.
+
+Practical `--latest` example:
+
+```yaml
+# before
+- uses: actions/checkout@v4
+- uses: owner/repo/path/to/action@0123456789abcdef0123456789abcdef01234567
+- uses: owner/repo/path/to/action@main
+- uses: ./.github/actions/setup
+- uses: docker://alpine:3.20
+
+# after running: gh pin-actions workflows --latest
+- uses: actions/checkout@<resolved-sha> #v4.x.y
+- uses: owner/repo/path/to/action@<resolved-sha> #v9.9.9
+- uses: owner/repo/path/to/action@<resolved-sha> #main
+- uses: ./.github/actions/setup
+- uses: docker://alpine:3.20
 ```
 
 >**Note**

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func GetActionHashByVersion(repository string, version string) (string, string, 
 	var tagVersion string
 	var std_err bytes.Buffer
 	var err error
-	repository = pkg.ExtractOwnerRepo(repository)
+	repository, _ = pkg.ExtractOwnerRepo(repository)
 	// Remove 'v' from the version string if sent through command line
 	version = strings.TrimPrefix(version, "v")
 	// Check to see if value received is latest version or a specific version
@@ -159,7 +159,7 @@ func GetLatestPatchVersion(repository string, version string) (string, error) {
 }
 
 func GetBranchHash(repository string, branch string) (string, error) {
-	repository = pkg.ExtractOwnerRepo(repository)
+	repository, _ = pkg.ExtractOwnerRepo(repository)
 	cliArgs := ".commit.sha"
 	cliOptions := fmt.Sprintf("repos/%s/branches/%s", repository, branch)
 	shaCommit, std_err, err := gh.Exec("api", cliOptions, "--jq", cliArgs)

--- a/cmd/workflows.go
+++ b/cmd/workflows.go
@@ -25,6 +25,7 @@ var (
 	}
 	logger             *pterm.Logger
 	overwriteWorkflows bool
+	latestWorkflows    bool
 )
 
 type Step struct {
@@ -46,6 +47,7 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	workflowsCmd.Flags().BoolVarP(&overwriteWorkflows, "overwrite", "o", false, "overwrite existing workflow files")
+	workflowsCmd.Flags().BoolVar(&latestWorkflows, "latest", false, "pin actions to the latest available release tags")
 	// rootCmd.MarkFlagRequired("repository")
 
 	// rootCmd.Flags().StringVarP(&version, "version", "v", "latest", "version of the tag to pin to (ex. 3; 3.1; 3.1.1)")
@@ -67,8 +69,9 @@ func processWorkflows(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	resolutionCache := newActionResolutionCache()
 	for _, file := range workflowFiles {
-		processActionsYaml(file)
+		processActionsYaml(file, latestWorkflows, resolutionCache)
 	}
 }
 
@@ -90,7 +93,7 @@ func getWorkflowFiles() ([]string, error) {
 	return workflowFiles, nil
 }
 
-func processActionsYaml(workflow string) {
+func processActionsYaml(workflow string, latestMode bool, resolutionCache pkg.ActionResolutionCache) {
 	var wf Workflow
 	data, err := os.ReadFile(workflow)
 	logger.Print("Processing workflow", logger.Args("file:", workflow))
@@ -107,29 +110,23 @@ func processActionsYaml(workflow string) {
 		logger.Warn("Error creating temp file", logger.Args("file:", workflow, "error:", err))
 	}
 
-	// Compile the regular expression before the loop
-	regHash, err := regexp.Compile(`@[0-9a-f]{40}`)
-	if err != nil {
-		logger.Warn("Error compiling Hash regex", logger.Args("error:", err))
-	}
-
 	// Loop through all the jobs and steps
 	for _, job := range wf.Jobs {
 		for i, step := range job.Steps {
 			logger.Trace("Processing Step", logger.Args("step:", fmt.Sprintf("%d %s", i+1, step.Name)))
 			if action := step.Uses; action != "" {
-				if matched := regHash.MatchString(action); matched {
-					// Action already has a hash
-					logger.Info("Action already has a hash", logger.Args("action:", action))
+				actionWithSha, shouldUpdate, err := processActionWithCache(action, latestMode, resolutionCache)
+				if err != nil {
+					logger.Warn("Nothing will be updated", logger.Args("action:", action, "error:", err))
 					continue
-				} else {
-					// Actions doesn't have a hash
-					actionWithSha, err := processAction(action)
-					if err != nil {
-						logger.Warn("Nothing will be updated")
-					}
-					writeModifiedWorkflowToFile(pinnedWorkflow, action, actionWithSha)
 				}
+				if !shouldUpdate {
+					continue
+				}
+				if latestMode {
+					logger.Info("Updating to latest", logger.Args("from:", action, "to:", actionWithSha))
+				}
+				writeModifiedWorkflowToFile(pinnedWorkflow, action, actionWithSha)
 			}
 		}
 	}
@@ -149,12 +146,18 @@ func processActionsYaml(workflow string) {
 func writeModifiedWorkflowToFile(fileName string, action string, actionWithSha string) {
 	if action == "" || actionWithSha == "" {
 		logger.Error("action or actionWithSha are empty", logger.Args("action:", action, "actionWithSha:", actionWithSha))
+		return
 	}
 	newFileContent, err := os.ReadFile(fileName)
 	if err != nil {
 		logger.Warn("Error reading file", logger.Args("file:", fileName, "error:", err))
+		return
 	}
-	modifiedContent := strings.Replace(string(newFileContent), action, actionWithSha, 1)
+	// Match the action plus any trailing inline #comment on the same line so that
+	// re-pinning an already-pinned action (e.g. with --latest) replaces the old
+	// version comment instead of leaving it alongside the new one.
+	pattern := regexp.MustCompile(regexp.QuoteMeta(action) + `(?:[ \t]+#[^\r\n]*)?`)
+	modifiedContent := pattern.ReplaceAllLiteralString(string(newFileContent), actionWithSha)
 	err = os.WriteFile(fileName, []byte(modifiedContent), 0644)
 	if err != nil {
 		logger.Warn("Error creating file", logger.Args("file:", fileName, "error:", err))
@@ -179,61 +182,34 @@ func createTempYAMLFile(fileName string) (string, error) {
 	return newFileName, nil
 }
 
-func processActionWithVersion(actionWithVersion string) (string, error) {
-	repoWithOwner, versionParsed, err := pkg.SplitActionString(actionWithVersion, "@v")
-	if err != nil {
-		return "", err
-	}
-	actionVersion := pkg.FormatVersion(versionParsed)
-	commitSha, tagVersion, err := GetActionHashByVersion(repoWithOwner, actionVersion)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s@%s #%s", repoWithOwner, strings.TrimSpace(commitSha), strings.TrimSpace(tagVersion)), nil
-
+func newActionResolutionCache() pkg.ActionResolutionCache {
+	return pkg.NewActionResolutionCache()
 }
 
-func processActionWithBranch(actionWithBranch string) (string, error) {
-	repoWithOwner, branchName, err := pkg.SplitActionString(actionWithBranch, "@")
-	if err != nil {
-		return "", err
+func warnUsesResolutionFailure(action string, err error) {
+	if logger == nil {
+		return
 	}
-	commitSha, err := GetBranchHash(repoWithOwner, branchName)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s@%s #%s", repoWithOwner, strings.TrimSpace(commitSha), strings.TrimSpace(branchName)), nil
+	logger.Warn("Unable to resolve action, keeping original uses value", logger.Args("action:", action, "error:", err))
 }
 
-func processAction(action string) (string, error) {
-	var actionWithSha string
-	branchRegex, err := regexp.Compile(`^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+$`)
-	if err != nil {
-		logger.Warn("Error compiling branch regex", logger.Args("error:", err))
-	}
-	if strings.Contains(action, "@v") {
-		// Action has a version
-		actionWithVersion := action
-		actionWithSha, err = processActionWithVersion(actionWithVersion)
-		if err != nil {
-			logger.Error("Error getting commit sha for action", logger.Args("action:", actionWithVersion, "error:", err))
-			actionWithSha = actionWithVersion
-			return actionWithSha, err
-		}
+type workflowResolverBackends struct {
+	resolveByVersion pkg.ActionVersionResolver
+	resolveByBranch  pkg.ActionBranchResolver
+}
 
-	} else if branchRegex.MatchString(action) {
-		// Action has a branch
-		actionWithBranch := action
-		actionWithSha, err = processActionWithBranch(actionWithBranch)
-		if err != nil {
-			logger.Error("Error getting commit sha for action with Branch", logger.Args("action:", actionWithBranch, "error:", err))
-			actionWithSha = actionWithBranch
-			return actionWithSha, err
-		}
-	} else if strings.Contains(action, "./") {
-		// Action is local
-		logger.Info("Action is local", logger.Args("action:", action))
-		return action, nil
+func defaultWorkflowResolverBackends() workflowResolverBackends {
+	return workflowResolverBackends{
+		resolveByVersion: GetActionHashByVersion,
+		resolveByBranch:  GetBranchHash,
 	}
-	return actionWithSha, nil
+}
+
+func processActionWithCache(action string, latestMode bool, resolutionCache pkg.ActionResolutionCache) (string, bool, error) {
+	backends := defaultWorkflowResolverBackends()
+	return processActionWithCacheWithResolvers(action, latestMode, resolutionCache, backends.resolveByVersion, backends.resolveByBranch)
+}
+
+func processActionWithCacheWithResolvers(action string, latestMode bool, resolutionCache pkg.ActionResolutionCache, resolveByVersion pkg.ActionVersionResolver, resolveByBranch pkg.ActionBranchResolver) (string, bool, error) {
+	return pkg.ProcessActionWithCache(action, latestMode, resolutionCache, resolveByVersion, resolveByBranch, warnUsesResolutionFailure)
 }

--- a/cmd/workflows_test.go
+++ b/cmd/workflows_test.go
@@ -1,14 +1,24 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/pterm/pterm"
 )
 
+func ensureTestLogger() {
+	if logger == nil {
+		logger = pterm.DefaultLogger.WithLevel(pterm.LogLevelWarn)
+	}
+}
+
 func TestGetWorkflowFiles(t *testing.T) {
-	// Setup: create a temporary directory with test files
 	tempDir := t.TempDir()
 	err := os.MkdirAll(filepath.Join(tempDir, ".github", "workflows"), 0755)
 	if err != nil {
@@ -27,7 +37,6 @@ func TestGetWorkflowFiles(t *testing.T) {
 		}
 	}
 
-	// Override the directory for testing
 	originalDir, _ := os.Getwd()
 	defer func() {
 		err := os.Chdir(originalDir)
@@ -69,20 +78,14 @@ func TestGetWorkflowFiles(t *testing.T) {
 }
 
 func TestCreateTempYAMLFile(t *testing.T) {
-	// Setup: create a temporary file
-	tempFile, err := os.CreateTemp("", "tempfile")
-	if err != nil {
-		t.Fatalf("Unexpected error creating temp file: %v", err)
-	}
-	defer tempFile.Close()
-
+	tempDir := t.TempDir()
+	originalFile := filepath.Join(tempDir, "workflow.yml")
 	content := []byte("test content")
-	if _, err := tempFile.Write(content); err != nil {
-		t.Fatalf("Unexpected error writing to temp file: %v", err)
+	if err := os.WriteFile(originalFile, content, 0644); err != nil {
+		t.Fatalf("Unexpected error writing source file: %v", err)
 	}
 
-	tempFileName := tempFile.Name()
-	newFileName, err := createTempYAMLFile(tempFileName)
+	newFileName, err := createTempYAMLFile(originalFile)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -99,4 +102,200 @@ func TestCreateTempYAMLFile(t *testing.T) {
 	if string(newContent) != string(content) {
 		t.Errorf("Expected content %s, got %s", string(content), string(newContent))
 	}
+}
+
+func TestWorkflowsLatestFlagWiring(t *testing.T) {
+	latestFlag := workflowsCmd.Flags().Lookup("latest")
+	if latestFlag == nil {
+		t.Fatal("expected workflows latest flag to be registered")
+	}
+
+	if latestFlag.DefValue != "false" {
+		t.Errorf("Expected default latest flag value false, got %s", latestFlag.DefValue)
+	}
+
+	if latestFlag.Usage == "" {
+		t.Error("Expected latest flag to include help text")
+	}
+}
+
+func TestDefaultWorkflowResolverBackendsUseCmdRootResolvers(t *testing.T) {
+	backends := defaultWorkflowResolverBackends()
+	if backends.resolveByVersion == nil {
+		t.Fatal("expected version resolver backend")
+	}
+	if backends.resolveByBranch == nil {
+		t.Fatal("expected branch resolver backend")
+	}
+
+	versionResolverName := runtime.FuncForPC(reflect.ValueOf(backends.resolveByVersion).Pointer()).Name()
+	if !strings.HasSuffix(versionResolverName, ".GetActionHashByVersion") {
+		t.Fatalf("expected GetActionHashByVersion backend, got %s", versionResolverName)
+	}
+
+	branchResolverName := runtime.FuncForPC(reflect.ValueOf(backends.resolveByBranch).Pointer()).Name()
+	if !strings.HasSuffix(branchResolverName, ".GetBranchHash") {
+		t.Fatalf("expected GetBranchHash backend, got %s", branchResolverName)
+	}
+}
+
+func TestProcessActionWithCacheWithResolversReusesLatestLookupBetweenVersionAndSHA(t *testing.T) {
+	var calls int
+	versionResolver := func(repository, version string) (string, string, error) {
+		calls++
+		if repository != "owner/repo" {
+			t.Errorf("Expected repository owner/repo, got %s", repository)
+		}
+		if version != "latest" {
+			t.Errorf("Expected version latest, got %s", version)
+		}
+		return "beadbead", "v7.1.0", nil
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		return "", nil
+	}
+
+	cache := newActionResolutionCache()
+	versionPinned, versionUpdated, versionErr := processActionWithCacheWithResolvers("owner/repo/path/to/action@v1", true, cache, versionResolver, branchResolver)
+	if versionErr != nil {
+		t.Fatalf("Unexpected error for version action: %v", versionErr)
+	}
+	if !versionUpdated {
+		t.Fatal("Expected version action to be updated")
+	}
+
+	shaPinned, shaUpdated, shaErr := processActionWithCacheWithResolvers("owner/repo/another/path/action@0123456789abcdef0123456789abcdef01234567", true, cache, versionResolver, branchResolver)
+	if shaErr != nil {
+		t.Fatalf("Unexpected error for sha action: %v", shaErr)
+	}
+	if !shaUpdated {
+		t.Fatal("Expected sha action to be updated")
+	}
+
+	if calls != 1 {
+		t.Fatalf("Expected resolver call to be reused from cache, got %d calls", calls)
+	}
+	if versionPinned != "owner/repo/path/to/action@beadbead #v7.1.0" {
+		t.Errorf("Unexpected pinned version action: %s", versionPinned)
+	}
+	if shaPinned != "owner/repo/another/path/action@beadbead #v7.1.0" {
+		t.Errorf("Unexpected pinned sha action: %s", shaPinned)
+	}
+}
+
+func TestProcessActionWithCacheWithResolversCachesResolutionFailures(t *testing.T) {
+	var calls int
+	versionResolver := func(repository, version string) (string, string, error) {
+		calls++
+		return "", "", errors.New("boom")
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		return "", nil
+	}
+
+	cache := newActionResolutionCache()
+	firstPinned, firstUpdated, firstErr := processActionWithCacheWithResolvers("actions/checkout@v4", true, cache, versionResolver, branchResolver)
+	secondPinned, secondUpdated, secondErr := processActionWithCacheWithResolvers("actions/checkout@v2", true, cache, versionResolver, branchResolver)
+
+	if firstErr != nil || secondErr != nil {
+		t.Fatalf("Expected failures to be handled without bubbling errors, got first=%v second=%v", firstErr, secondErr)
+	}
+	if firstUpdated || secondUpdated {
+		t.Fatal("Expected unresolved actions to remain unchanged")
+	}
+	if firstPinned != "" || secondPinned != "" {
+		t.Fatalf("Expected no pinned output on failure, got first=%q second=%q", firstPinned, secondPinned)
+	}
+	if calls != 1 {
+		t.Fatalf("Expected failure result to be cached, got %d calls", calls)
+	}
+}
+
+
+
+func TestWriteModifiedWorkflowToFile(t *testing.T) {
+ensureTestLogger()
+
+tests := []struct {
+name          string
+initialLine   string
+action        string
+actionWithSha string
+expectedLine  string
+}{
+{
+name:          "first pin: version ref without existing comment",
+initialLine:   "      uses: actions/checkout@v4\n",
+action:        "actions/checkout@v4",
+actionWithSha: "actions/checkout@abc123 #v4.1.0",
+expectedLine:  "      uses: actions/checkout@abc123 #v4.1.0\n",
+},
+{
+name:          "re-pin with --latest: removes existing #comment",
+initialLine:   "      uses: actions/setup-go@oldsha #v4.1.0\n",
+action:        "actions/setup-go@oldsha",
+actionWithSha: "actions/setup-go@newsha #v6.4.0",
+expectedLine:  "      uses: actions/setup-go@newsha #v6.4.0\n",
+},
+{
+name:          "re-pin with --latest: removes existing #comment with extra spaces",
+initialLine:   "      uses: actions/checkout@oldsha    #v4.1.0\n",
+action:        "actions/checkout@oldsha",
+actionWithSha: "actions/checkout@newsha #v6.0.2",
+expectedLine:  "      uses: actions/checkout@newsha #v6.0.2\n",
+},
+{
+name:          "re-pin with --latest: subpath action with existing comment",
+initialLine:   "      uses: owner/repo/sub-action@oldsha #v1.2.3\n",
+action:        "owner/repo/sub-action@oldsha",
+actionWithSha: "owner/repo/sub-action@newsha #v2.0.0",
+expectedLine:  "      uses: owner/repo/sub-action@newsha #v2.0.0\n",
+},
+{
+name:          "no trailing comment on line: replaces cleanly",
+initialLine:   "      uses: actions/checkout@v3  \n",
+action:        "actions/checkout@v3",
+actionWithSha: "actions/checkout@abc123 #v3.5.3",
+expectedLine:  "      uses: actions/checkout@abc123 #v3.5.3  \n",
+},
+{
+name:          "does not consume comment on a following line",
+initialLine:   "      uses: actions/checkout@v3\n      # keep this comment\n",
+action:        "actions/checkout@v3",
+actionWithSha: "actions/checkout@abc123 #v3.5.3",
+expectedLine:  "      uses: actions/checkout@abc123 #v3.5.3\n      # keep this comment\n",
+},
+{
+name:          "action not present in file: file unchanged",
+initialLine:   "      uses: actions/checkout@v4\n",
+action:        "actions/setup-go@v5",
+actionWithSha: "actions/setup-go@abc #v5.0.0",
+expectedLine:  "      uses: actions/checkout@v4\n",
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+tmpFile, err := os.CreateTemp("", "workflow-*.yml")
+if err != nil {
+t.Fatalf("failed to create temp file: %v", err)
+}
+defer os.Remove(tmpFile.Name())
+
+if _, err := tmpFile.WriteString(tt.initialLine); err != nil {
+t.Fatalf("failed to write temp file: %v", err)
+}
+tmpFile.Close()
+
+writeModifiedWorkflowToFile(tmpFile.Name(), tt.action, tt.actionWithSha)
+
+got, err := os.ReadFile(tmpFile.Name())
+if err != nil {
+t.Fatalf("failed to read temp file: %v", err)
+}
+if string(got) != tt.expectedLine {
+t.Errorf("writeModifiedWorkflowToFile mismatch\n got:  %q\n want: %q", string(got), tt.expectedLine)
+}
+})
+}
 }

--- a/pkg/action_resolution.go
+++ b/pkg/action_resolution.go
@@ -1,0 +1,193 @@
+package pkg
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ActionVersionResolver resolves a repository + version to (commitSHA, tagVersion, error).
+// Maps directly to GetActionHashByVersion in cmd/root.go.
+type ActionVersionResolver func(repository, version string) (string, string, error)
+
+// ActionBranchResolver resolves a repository + branch to (commitSHA, error).
+// Maps directly to GetBranchHash in cmd/root.go.
+type ActionBranchResolver func(repository, branch string) (string, error)
+
+// ResolutionFailureWarning is called when resolution fails, allowing the caller
+// to log a warning without halting processing of remaining actions.
+type ResolutionFailureWarning func(action string, err error)
+
+type actionLookupKind string
+
+const (
+	actionLookupVersion actionLookupKind = "version"
+	actionLookupBranch  actionLookupKind = "branch"
+)
+
+// ActionResolutionCacheKey identifies a unique resolver lookup so duplicate
+// API calls across workflow files/jobs can be avoided.
+type ActionResolutionCacheKey struct {
+	Repository string
+	Mode       string
+	Kind       actionLookupKind
+	Ref        string
+}
+
+type actionResolutionCacheEntry struct {
+	commitSHA   string
+	resolvedRef string
+	err         error
+}
+
+// ActionResolutionCache stores resolver results keyed by (repo, mode, kind, ref).
+type ActionResolutionCache map[ActionResolutionCacheKey]actionResolutionCacheEntry
+
+func NewActionResolutionCache() ActionResolutionCache {
+	return make(ActionResolutionCache)
+}
+
+func formatPinnedAction(actionPath, commitSHA, resolvedRef string) string {
+	return fmt.Sprintf("%s@%s #%s", actionPath, commitSHA, resolvedRef)
+}
+
+func lookupModeName(latestMode bool) string {
+	if latestMode {
+		return "latest"
+	}
+	return "default"
+}
+
+// normalizedVersionLookupRef determines which version string to pass to
+// GetActionHashByVersion: "latest" in latest mode, or the formatted version.
+func normalizedVersionLookupRef(ref string, latestMode bool) (string, bool) {
+	if latestMode {
+		return "latest", true
+	}
+	versionToResolve := strings.TrimPrefix(strings.TrimSpace(ref), "v")
+	if versionToResolve == "" {
+		return "", false
+	}
+	return FormatVersion(versionToResolve), true
+}
+
+func buildResolutionCacheKey(action UsesRefMetadata, latestMode bool) (ActionResolutionCacheKey, bool) {
+	if action.BaseRepo == "" || action.ActionPath == "" || action.Ref == "" {
+		return ActionResolutionCacheKey{}, false
+	}
+
+	switch action.Class {
+	case UsesRefVersion:
+		versionRef, ok := normalizedVersionLookupRef(action.Ref, latestMode)
+		if !ok {
+			return ActionResolutionCacheKey{}, false
+		}
+		return ActionResolutionCacheKey{
+			Repository: action.BaseRepo,
+			Mode:       lookupModeName(latestMode),
+			Kind:       actionLookupVersion,
+			Ref:        versionRef,
+		}, true
+	case UsesRefSHA:
+		if !latestMode {
+			return ActionResolutionCacheKey{}, false
+		}
+		return ActionResolutionCacheKey{
+			Repository: action.BaseRepo,
+			Mode:       lookupModeName(latestMode),
+			Kind:       actionLookupVersion,
+			Ref:        "latest",
+		}, true
+	case UsesRefBranch:
+		return ActionResolutionCacheKey{
+			Repository: action.BaseRepo,
+			Mode:       lookupModeName(latestMode),
+			Kind:       actionLookupBranch,
+			Ref:        strings.TrimSpace(action.Ref),
+		}, true
+	default:
+		return ActionResolutionCacheKey{}, false
+	}
+}
+
+// resolveAndPin calls GetActionHashByVersion or GetBranchHash directly
+// based on the ref type — no intermediate wrapper layers.
+func resolveAndPin(refMeta UsesRefMetadata, latestMode bool, resolveByVersion ActionVersionResolver, resolveByBranch ActionBranchResolver) (commitSHA, resolvedRef string, err error) {
+	switch refMeta.Class {
+	case UsesRefVersion, UsesRefSHA:
+		// For SHA refs, always resolve as "latest"; for version refs, respect latestMode
+		effectiveLatest := latestMode || refMeta.Class == UsesRefSHA
+		versionRef, ok := normalizedVersionLookupRef(refMeta.Ref, effectiveLatest)
+		if !ok {
+			return "", "", fmt.Errorf("invalid action format: %s@%s", refMeta.ActionPath, refMeta.Ref)
+		}
+		commitSHA, resolvedRef, err = resolveByVersion(refMeta.BaseRepo, versionRef)
+		if err != nil {
+			return "", "", err
+		}
+		return strings.TrimSpace(commitSHA), strings.TrimSpace(resolvedRef), nil
+
+	case UsesRefBranch:
+		branch := strings.TrimSpace(refMeta.Ref)
+		commitSHA, err = resolveByBranch(refMeta.BaseRepo, branch)
+		if err != nil {
+			return "", "", err
+		}
+		return strings.TrimSpace(commitSHA), branch, nil
+
+	default:
+		return "", "", fmt.Errorf("unsupported action format: %s@%s", refMeta.ActionPath, refMeta.Ref)
+	}
+}
+
+// ProcessActionWithCache is the single entry point for resolving and pinning an action.
+// It classifies the ref, checks the cache, calls the resolver (GetActionHashByVersion
+// or GetBranchHash), caches the result, and returns the pinned string.
+// On failure it warns and returns ("", false, nil) so processing continues.
+func ProcessActionWithCache(action string, latestMode bool, resolutionCache ActionResolutionCache, resolveByVersion ActionVersionResolver, resolveByBranch ActionBranchResolver, warnResolutionFailure ResolutionFailureWarning) (string, bool, error) {
+	refMeta := ClassifyUsesRef(action)
+
+	// Skip refs we don't resolve
+	switch refMeta.Class {
+	case UsesRefLocal, UsesRefUnsupported:
+		return "", false, nil
+	case UsesRefSHA:
+		if !latestMode {
+			return "", false, nil
+		}
+	}
+
+	// Check cache
+	cacheKey, cacheable := buildResolutionCacheKey(refMeta, latestMode)
+	if cacheable && resolutionCache != nil {
+		if entry, ok := resolutionCache[cacheKey]; ok {
+			if entry.err != nil {
+				if warnResolutionFailure != nil {
+					warnResolutionFailure(action, entry.err)
+				}
+				return "", false, nil
+			}
+			return formatPinnedAction(refMeta.ActionPath, entry.commitSHA, entry.resolvedRef), true, nil
+		}
+	}
+
+	// Call GetActionHashByVersion or GetBranchHash directly
+	commitSHA, resolvedRef, err := resolveAndPin(refMeta, latestMode, resolveByVersion, resolveByBranch)
+
+	// Cache the result (success or failure)
+	if cacheable && resolutionCache != nil {
+		resolutionCache[cacheKey] = actionResolutionCacheEntry{
+			commitSHA:   commitSHA,
+			resolvedRef: resolvedRef,
+			err:         err,
+		}
+	}
+
+	if err != nil {
+		if warnResolutionFailure != nil {
+			warnResolutionFailure(action, err)
+		}
+		return "", false, nil
+	}
+
+	return formatPinnedAction(refMeta.ActionPath, commitSHA, resolvedRef), true, nil
+}

--- a/pkg/action_resolution_test.go
+++ b/pkg/action_resolution_test.go
@@ -1,0 +1,479 @@
+package pkg
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProcessActionWithCacheVersionRefResolvesCorrectly(t *testing.T) {
+	var called bool
+	resolver := func(repository, version string) (string, string, error) {
+		called = true
+		if repository != "actions/checkout" {
+			t.Errorf("Expected repository actions/checkout, got %s", repository)
+		}
+		if version != "3" {
+			t.Errorf("Expected version 3, got %s", version)
+		}
+		return "abc123", "v3.5.1", nil
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		t.Fatal("Branch resolver should not be called for version refs")
+		return "", nil
+	}
+
+	cache := NewActionResolutionCache()
+	got, updated, err := ProcessActionWithCache("actions/checkout@v3", false, cache, resolver, branchResolver, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("Expected version resolver to be called")
+	}
+	if !updated {
+		t.Fatal("Expected action to be updated")
+	}
+	if got != "actions/checkout@abc123 #v3.5.1" {
+		t.Errorf("Unexpected pinned action: %s", got)
+	}
+}
+
+func TestProcessActionWithCacheVersionRefLatestMode(t *testing.T) {
+	resolver := func(repository, version string) (string, string, error) {
+		if repository != "actions/checkout" {
+			t.Errorf("Expected repository actions/checkout, got %s", repository)
+		}
+		if version != "latest" {
+			t.Errorf("Expected version latest, got %s", version)
+		}
+		return "cafebabe", "v5.0.0", nil
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		t.Fatal("Branch resolver should not be called for version refs")
+		return "", nil
+	}
+
+	cache := NewActionResolutionCache()
+	got, updated, err := ProcessActionWithCache("actions/checkout@v3", true, cache, resolver, branchResolver, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !updated {
+		t.Fatal("Expected action to be updated")
+	}
+	if got != "actions/checkout@cafebabe #v5.0.0" {
+		t.Errorf("Unexpected pinned action: %s", got)
+	}
+}
+
+func TestProcessActionWithCacheSHARefDefaultVsLatestMode(t *testing.T) {
+	var calls int
+	versionResolver := func(repository, version string) (string, string, error) {
+		calls++
+		if repository != "owner/repo" {
+			t.Errorf("Expected repository owner/repo, got %s", repository)
+		}
+		if version != "latest" {
+			t.Errorf("Expected version latest, got %s", version)
+		}
+		return "deadc0de", "v10.2.0", nil
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		return "", nil
+	}
+
+	action := "owner/repo/path/to/action@0123456789abcdef0123456789abcdef01234567"
+
+	// Default mode: SHA ref should be skipped
+	cache := NewActionResolutionCache()
+	defaultPinned, defaultUpdated, defaultErr := ProcessActionWithCache(action, false, cache, versionResolver, branchResolver, nil)
+	if defaultErr != nil {
+		t.Fatalf("Unexpected error in default mode: %v", defaultErr)
+	}
+	if defaultUpdated {
+		t.Fatal("Expected sha ref to remain unchanged in default mode")
+	}
+	if defaultPinned != "" {
+		t.Errorf("Expected no replacement action in default mode, got %q", defaultPinned)
+	}
+	if calls != 0 {
+		t.Fatalf("Expected resolver not to be called in default mode, got %d", calls)
+	}
+
+	// Latest mode: SHA ref should be re-pinned
+	cache = NewActionResolutionCache()
+	latestPinned, latestUpdated, latestErr := ProcessActionWithCache(action, true, cache, versionResolver, branchResolver, nil)
+	if latestErr != nil {
+		t.Fatalf("Unexpected error in latest mode: %v", latestErr)
+	}
+	if !latestUpdated {
+		t.Fatal("Expected sha ref to be re-pinned in latest mode")
+	}
+	if calls != 1 {
+		t.Fatalf("Expected resolver to be called once in latest mode, got %d", calls)
+	}
+	if latestPinned != "owner/repo/path/to/action@deadc0de #v10.2.0" {
+		t.Errorf("Unexpected pinned action in latest mode: %s", latestPinned)
+	}
+}
+
+func TestProcessActionWithCacheBranchRefBehavesSameInDefaultAndLatestModes(t *testing.T) {
+	var branchCalls int
+	var versionCalls int
+	branchResolver := func(repository, branch string) (string, error) {
+		branchCalls++
+		if repository != "owner/repo" {
+			t.Errorf("Expected repository owner/repo, got %s", repository)
+		}
+		if branch != "release/v1.2" {
+			t.Errorf("Expected branch release/v1.2, got %s", branch)
+		}
+		return "1234abcd", nil
+	}
+	versionResolver := func(repository, version string) (string, string, error) {
+		versionCalls++
+		return "", "", nil
+	}
+
+	action := "owner/repo/path/to/action@release/v1.2"
+
+	cache := NewActionResolutionCache()
+	defaultPinned, defaultUpdated, defaultErr := ProcessActionWithCache(action, false, cache, versionResolver, branchResolver, nil)
+	if defaultErr != nil {
+		t.Fatalf("Unexpected error in default mode: %v", defaultErr)
+	}
+	if !defaultUpdated {
+		t.Fatal("Expected branch ref to be updated in default mode")
+	}
+
+	cache = NewActionResolutionCache()
+	latestPinned, latestUpdated, latestErr := ProcessActionWithCache(action, true, cache, versionResolver, branchResolver, nil)
+	if latestErr != nil {
+		t.Fatalf("Unexpected error in latest mode: %v", latestErr)
+	}
+	if !latestUpdated {
+		t.Fatal("Expected branch ref to be updated in latest mode")
+	}
+
+	expectedPinned := "owner/repo/path/to/action@1234abcd #release/v1.2"
+	if defaultPinned != expectedPinned {
+		t.Errorf("Unexpected pinned action in default mode: %s", defaultPinned)
+	}
+	if latestPinned != expectedPinned {
+		t.Errorf("Unexpected pinned action in latest mode: %s", latestPinned)
+	}
+	if branchCalls != 2 {
+		t.Fatalf("Expected branch resolver to be called twice, got %d", branchCalls)
+	}
+	if versionCalls != 0 {
+		t.Fatalf("Expected version resolver not to be called for branch refs, got %d", versionCalls)
+	}
+}
+
+func TestProcessActionWithCacheReusesLatestLookupBetweenVersionAndSHA(t *testing.T) {
+	var calls int
+	versionResolver := func(repository, version string) (string, string, error) {
+		calls++
+		if repository != "owner/repo" {
+			t.Errorf("Expected repository owner/repo, got %s", repository)
+		}
+		if version != "latest" {
+			t.Errorf("Expected version latest, got %s", version)
+		}
+		return "beadbead", "v7.1.0", nil
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		return "", nil
+	}
+
+	cache := NewActionResolutionCache()
+	versionPinned, versionUpdated, versionErr := ProcessActionWithCache("owner/repo/path/to/action@v1", true, cache, versionResolver, branchResolver, nil)
+	if versionErr != nil {
+		t.Fatalf("Unexpected error for version action: %v", versionErr)
+	}
+	if !versionUpdated {
+		t.Fatal("Expected version action to be updated")
+	}
+
+	shaPinned, shaUpdated, shaErr := ProcessActionWithCache("owner/repo/another/path/action@0123456789abcdef0123456789abcdef01234567", true, cache, versionResolver, branchResolver, nil)
+	if shaErr != nil {
+		t.Fatalf("Unexpected error for sha action: %v", shaErr)
+	}
+	if !shaUpdated {
+		t.Fatal("Expected sha action to be updated")
+	}
+
+	if calls != 1 {
+		t.Fatalf("Expected resolver call to be reused from cache, got %d calls", calls)
+	}
+	if versionPinned != "owner/repo/path/to/action@beadbead #v7.1.0" {
+		t.Errorf("Unexpected pinned version action: %s", versionPinned)
+	}
+	if shaPinned != "owner/repo/another/path/action@beadbead #v7.1.0" {
+		t.Errorf("Unexpected pinned sha action: %s", shaPinned)
+	}
+}
+
+func TestProcessActionWithCacheCachesResolutionFailures(t *testing.T) {
+	var calls int
+	var warnings int
+	versionResolver := func(repository, version string) (string, string, error) {
+		calls++
+		return "", "", errors.New("boom")
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		return "", nil
+	}
+	warn := func(action string, err error) {
+		warnings++
+	}
+
+	cache := NewActionResolutionCache()
+	firstPinned, firstUpdated, firstErr := ProcessActionWithCache("actions/checkout@v4", true, cache, versionResolver, branchResolver, warn)
+	secondPinned, secondUpdated, secondErr := ProcessActionWithCache("actions/checkout@v2", true, cache, versionResolver, branchResolver, warn)
+
+	if firstErr != nil || secondErr != nil {
+		t.Fatalf("Expected failures to be handled without bubbling errors, got first=%v second=%v", firstErr, secondErr)
+	}
+	if firstUpdated || secondUpdated {
+		t.Fatal("Expected unresolved actions to remain unchanged")
+	}
+	if firstPinned != "" || secondPinned != "" {
+		t.Fatalf("Expected no pinned output on failure, got first=%q second=%q", firstPinned, secondPinned)
+	}
+	if calls != 1 {
+		t.Fatalf("Expected failure result to be cached, got %d calls", calls)
+	}
+	if warnings != 2 {
+		t.Fatalf("Expected warnings for each unresolved action, got %d", warnings)
+	}
+}
+
+func TestProcessActionWithCacheSkipsLocalAndUnsupportedRefsWithoutResolverCalls(t *testing.T) {
+	var versionCalls int
+	var branchCalls int
+	versionResolver := func(repository, version string) (string, string, error) {
+		versionCalls++
+		return "", "", nil
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		branchCalls++
+		return "", nil
+	}
+
+	tests := []struct {
+		name   string
+		action string
+	}{
+		{
+			name:   "local action",
+			action: "./.github/actions/setup",
+		},
+		{
+			name:   "unsupported docker action",
+			action: "docker://alpine:3.20",
+		},
+		{
+			name:   "unsupported external action",
+			action: "actions/checkout",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		for _, latestMode := range []bool{false, true} {
+			latestMode := latestMode
+			modeName := "default"
+			if latestMode {
+				modeName = "latest"
+			}
+			t.Run(tt.name+" in "+modeName+" mode", func(t *testing.T) {
+				cache := NewActionResolutionCache()
+				got, shouldUpdate, err := ProcessActionWithCache(tt.action, latestMode, cache, versionResolver, branchResolver, nil)
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if shouldUpdate {
+					t.Fatal("Expected action to remain unchanged")
+				}
+				if got != "" {
+					t.Errorf("Expected no replacement action, got %q", got)
+				}
+			})
+		}
+	}
+
+	if versionCalls != 0 {
+		t.Fatalf("Expected version resolver not to be called, got %d", versionCalls)
+	}
+	if branchCalls != 0 {
+		t.Fatalf("Expected branch resolver not to be called, got %d", branchCalls)
+	}
+}
+
+func TestProcessActionWithCacheFormatMatrix(t *testing.T) {
+	// Tests all documented action formats through ProcessActionWithCache in both modes,
+	// verifying correct repo is sent to resolver and subpath is preserved in output.
+	versionResolver := func(repository, version string) (string, string, error) {
+		return "abc123sha", "v5.0.0", nil
+	}
+	branchResolver := func(repository, branch string) (string, error) {
+		return "def456sha", nil
+	}
+
+	tests := []struct {
+		name           string
+		action         string
+		latestMode     bool
+		expectedOutput string
+		expectedUpdate bool
+		expectedRepo   string // repo sent to resolver
+	}{
+		// owner/repo@version — default mode
+		{
+			name:           "owner/repo@version default",
+			action:         "actions/checkout@v3",
+			latestMode:     false,
+			expectedOutput: "actions/checkout@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "actions/checkout",
+		},
+		// owner/repo@version — latest mode
+		{
+			name:           "owner/repo@version latest",
+			action:         "actions/checkout@v3",
+			latestMode:     true,
+			expectedOutput: "actions/checkout@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "actions/checkout",
+		},
+		// owner/repo/sub-action@version — default mode (subpath preserved)
+		{
+			name:           "owner/repo/sub-action@version default",
+			action:         "owner/repo/sub-action@v2",
+			latestMode:     false,
+			expectedOutput: "owner/repo/sub-action@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "owner/repo",
+		},
+		// owner/repo/sub-action@version — latest mode (subpath preserved)
+		{
+			name:           "owner/repo/sub-action@version latest",
+			action:         "owner/repo/sub-action@v2",
+			latestMode:     true,
+			expectedOutput: "owner/repo/sub-action@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "owner/repo",
+		},
+		// owner/repo@branch — default mode
+		{
+			name:           "owner/repo@branch default",
+			action:         "actions/checkout@main",
+			latestMode:     false,
+			expectedOutput: "actions/checkout@def456sha #main",
+			expectedUpdate: true,
+			expectedRepo:   "actions/checkout",
+		},
+		// owner/repo@branch — latest mode (same behavior)
+		{
+			name:           "owner/repo@branch latest",
+			action:         "actions/checkout@main",
+			latestMode:     true,
+			expectedOutput: "actions/checkout@def456sha #main",
+			expectedUpdate: true,
+			expectedRepo:   "actions/checkout",
+		},
+		// owner/repo/sub-action@branch — default mode
+		{
+			name:           "owner/repo/sub-action@branch default",
+			action:         "owner/repo/sub-action@develop",
+			latestMode:     false,
+			expectedOutput: "owner/repo/sub-action@def456sha #develop",
+			expectedUpdate: true,
+			expectedRepo:   "owner/repo",
+		},
+		// owner/repo@sha — default mode (skip)
+		{
+			name:           "owner/repo@sha default skipped",
+			action:         "actions/checkout@0123456789abcdef0123456789abcdef01234567",
+			latestMode:     false,
+			expectedOutput: "",
+			expectedUpdate: false,
+			expectedRepo:   "",
+		},
+		// owner/repo@sha — latest mode (repin)
+		{
+			name:           "owner/repo@sha latest repin",
+			action:         "actions/checkout@0123456789abcdef0123456789abcdef01234567",
+			latestMode:     true,
+			expectedOutput: "actions/checkout@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "actions/checkout",
+		},
+		// owner/repo/sub-action@sha — latest mode (subpath preserved)
+		{
+			name:           "owner/repo/sub-action@sha latest repin",
+			action:         "owner/repo/sub-action@0123456789abcdef0123456789abcdef01234567",
+			latestMode:     true,
+			expectedOutput: "owner/repo/sub-action@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "owner/repo",
+		},
+		// owner/repo/sub-action@branchName with slash
+		{
+			name:           "owner/repo/sub-action@branch-with-slash",
+			action:         "owner/repo/sub-action@release/v1.2",
+			latestMode:     false,
+			expectedOutput: "owner/repo/sub-action@def456sha #release/v1.2",
+			expectedUpdate: true,
+			expectedRepo:   "owner/repo",
+		},
+		// version without v prefix
+		{
+			name:           "version without v prefix",
+			action:         "actions/setup-go@3.2",
+			latestMode:     false,
+			expectedOutput: "actions/setup-go@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "actions/setup-go",
+		},
+		// major-only version
+		{
+			name:           "major-only version",
+			action:         "actions/checkout@4",
+			latestMode:     false,
+			expectedOutput: "actions/checkout@abc123sha #v5.0.0",
+			expectedUpdate: true,
+			expectedRepo:   "actions/checkout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedRepo string
+			testVersionResolver := func(repository, version string) (string, string, error) {
+				capturedRepo = repository
+				return versionResolver(repository, version)
+			}
+			testBranchResolver := func(repository, branch string) (string, error) {
+				capturedRepo = repository
+				return branchResolver(repository, branch)
+			}
+
+			cache := NewActionResolutionCache()
+			got, updated, err := ProcessActionWithCache(tt.action, tt.latestMode, cache, testVersionResolver, testBranchResolver, nil)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if updated != tt.expectedUpdate {
+				t.Errorf("Expected updated=%t, got %t", tt.expectedUpdate, updated)
+			}
+			if got != tt.expectedOutput {
+				t.Errorf("Expected output %q, got %q", tt.expectedOutput, got)
+			}
+			if tt.expectedRepo != "" && capturedRepo != tt.expectedRepo {
+				t.Errorf("Expected repo sent to resolver %q, got %q", tt.expectedRepo, capturedRepo)
+			}
+		})
+	}
+}

--- a/pkg/action_utils.go
+++ b/pkg/action_utils.go
@@ -1,26 +1,32 @@
 package pkg
 
 import (
-	"fmt"
 	"strings"
 )
 
-func SplitActionString(action string, delimiter string) (string, string, error) {
-	actionSplit := strings.Split(action, delimiter)
-	if len(actionSplit) < 2 {
-		return "", "", fmt.Errorf("invalid action format: %s", action)
+func splitOnLastAt(value string) (string, string, bool) {
+	lastAt := strings.LastIndex(value, "@")
+	if lastAt == -1 {
+		return value, "", false
 	}
-	repoWithOwner := actionSplit[0]
-	branchOrVersion := actionSplit[1]
-	return repoWithOwner, branchOrVersion, nil
+
+	return value[:lastAt], value[lastAt+1:], true
 }
 
-func ExtractOwnerRepo(repository string) string {
-	if strings.Count(repository, "/") > 1 {
-		parts := strings.Split(repository, "/")
-		if len(parts) > 2 {
-			repository = parts[0] + "/" + parts[1]
-		}
+// ExtractOwnerRepo extracts the "owner/repo" base from an action path
+// that may include subpaths (e.g., "owner/repo/sub/path" → "owner/repo").
+// Returns false if the path doesn't contain a valid owner/repo pair.
+func ExtractOwnerRepo(actionPath string) (string, bool) {
+	parts := strings.Split(actionPath, "/")
+	if len(parts) < 2 {
+		return "", false
 	}
-	return repository
+
+	owner := parts[0]
+	repo := parts[1]
+	if owner == "" || repo == "" {
+		return "", false
+	}
+
+	return owner + "/" + repo, true
 }

--- a/pkg/action_utils_test.go
+++ b/pkg/action_utils_test.go
@@ -1,52 +1,112 @@
 package pkg
 
 import (
-	"fmt"
 	"testing"
 )
 
-func TestSplitActionString(t *testing.T) {
-	tests := []struct {
-		action      string
-		delimiter   string
-		expected1   string
-		expected2   string
-		expectedErr error
-	}{
-		{"owner/repo@v3", "@v", "owner/repo", "3", nil},
-		{"owner/repo@main", "@", "owner/repo", "main", nil},
-		{"owner/repo@v3.3.3", "@v", "owner/repo", "3.3.3", nil},
-		{"repo", "/", "", "", fmt.Errorf("invalid action format: repo")},
-		{"repo", "|", "", "", fmt.Errorf("invalid action format: repo")},
-	}
-
-	for _, test := range tests {
-		result1, result2, err := SplitActionString(test.action, test.delimiter)
-		if err != nil && test.expectedErr == nil {
-			t.Errorf("Unexpected error for action %s: %v", test.action, err)
-		} else if err == nil && test.expectedErr != nil {
-			t.Errorf("Expected error for action %s: %v", test.action, test.expectedErr)
-		} else if result1 != test.expected1 || result2 != test.expected2 {
-			t.Errorf("Unexpected result for action %s: got (%s, %s), want (%s, %s)", test.action, result1, result2, test.expected1, test.expected2)
-		}
-	}
-}
 func TestExtractOwnerRepo(t *testing.T) {
 	tests := []struct {
-		repository string
-		expected   string
+		name         string
+		actionPath   string
+		expectedRepo string
+		expectedOK   bool
 	}{
-		{"owner/repo", "owner/repo"},
-		{"owner/repo/sub", "owner/repo"},
-		{"owner/repo/sub/sub", "owner/repo"},
-		{"repo", "repo"},
-		{"", ""},
+		{
+			name:         "owner repo only",
+			actionPath:   "owner/repo",
+			expectedRepo: "owner/repo",
+			expectedOK:   true,
+		},
+		{
+			name:         "owner repo with subpath",
+			actionPath:   "owner/repo/path/to/action",
+			expectedRepo: "owner/repo",
+			expectedOK:   true,
+		},
+		{
+			name:         "owner repo with single subpath",
+			actionPath:   "owner/repo/sub",
+			expectedRepo: "owner/repo",
+			expectedOK:   true,
+		},
+		{
+			name:       "missing repo",
+			actionPath: "owner/",
+			expectedOK: false,
+		},
+		{
+			name:       "missing owner",
+			actionPath: "/repo",
+			expectedOK: false,
+		},
+		{
+			name:       "single path segment",
+			actionPath: "repo",
+			expectedOK: false,
+		},
+		{
+			name:       "empty string",
+			actionPath: "",
+			expectedOK: false,
+		},
 	}
 
 	for _, test := range tests {
-		result := ExtractOwnerRepo(test.repository)
-		if result != test.expected {
-			t.Errorf("Unexpected result for repository %s: got %s, want %s", test.repository, result, test.expected)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			repo, ok := ExtractOwnerRepo(test.actionPath)
+			if repo != test.expectedRepo || ok != test.expectedOK {
+				t.Errorf("ExtractOwnerRepo(%q) = (%q, %t), want (%q, %t)", test.actionPath, repo, ok, test.expectedRepo, test.expectedOK)
+			}
+		})
 	}
 }
+
+func TestSplitOnLastAt(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		expectedPath string
+		expectedRef  string
+		expectedHas  bool
+	}{
+		{
+			name:         "splits once",
+			value:        "actions/checkout@v4",
+			expectedPath: "actions/checkout",
+			expectedRef:  "v4",
+			expectedHas:  true,
+		},
+		{
+			name:         "splits on final at",
+			value:        "owner/repo@release@candidate",
+			expectedPath: "owner/repo@release",
+			expectedRef:  "candidate",
+			expectedHas:  true,
+		},
+		{
+			name:         "no at",
+			value:        "actions/checkout",
+			expectedPath: "actions/checkout",
+			expectedRef:  "",
+			expectedHas:  false,
+		},
+		{
+			name:         "trailing at",
+			value:        "owner/repo@",
+			expectedPath: "owner/repo",
+			expectedRef:  "",
+			expectedHas:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path, ref, hasRef := splitOnLastAt(test.value)
+			if path != test.expectedPath || ref != test.expectedRef || hasRef != test.expectedHas {
+				t.Errorf("splitOnLastAt(%q) = (%q, %q, %t), want (%q, %q, %t)", test.value, path, ref, hasRef, test.expectedPath, test.expectedRef, test.expectedHas)
+			}
+		})
+	}
+}
+
+

--- a/pkg/ref_classifier.go
+++ b/pkg/ref_classifier.go
@@ -1,0 +1,75 @@
+package pkg
+
+import (
+	"regexp"
+	"strings"
+)
+
+type UsesRefClass string
+
+const (
+	UsesRefLocal       UsesRefClass = "local"
+	UsesRefVersion     UsesRefClass = "version"
+	UsesRefBranch      UsesRefClass = "branch"
+	UsesRefSHA         UsesRefClass = "sha"
+	UsesRefUnsupported UsesRefClass = "unsupported"
+)
+
+type UsesRefMetadata struct {
+	Class      UsesRefClass
+	ActionPath string
+	BaseRepo   string
+	Ref        string
+}
+
+var (
+	versionRefPattern = regexp.MustCompile(`^v?\d+(?:\.\d+){0,2}$`)
+	shaRefPattern     = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
+)
+
+func ClassifyUsesRef(uses string) UsesRefMetadata {
+	uses = strings.TrimSpace(uses)
+	if uses == "" {
+		return UsesRefMetadata{Class: UsesRefUnsupported}
+	}
+
+	if strings.HasPrefix(uses, "docker://") {
+		return UsesRefMetadata{
+			Class:      UsesRefUnsupported,
+			ActionPath: uses,
+		}
+	}
+
+	actionPath, ref, _ := splitOnLastAt(uses)
+
+	if strings.HasPrefix(actionPath, "./") {
+		return UsesRefMetadata{
+			Class:      UsesRefLocal,
+			ActionPath: actionPath,
+			Ref:        ref,
+		}
+	}
+
+	baseRepo, _ := ExtractOwnerRepo(actionPath)
+	result := UsesRefMetadata{
+		ActionPath: actionPath,
+		BaseRepo:   baseRepo,
+		Ref:        ref,
+	}
+
+	if baseRepo == "" || actionPath == "" || ref == "" {
+		result.Class = UsesRefUnsupported
+		return result
+	}
+
+	switch {
+	case shaRefPattern.MatchString(ref):
+		result.Class = UsesRefSHA
+	case versionRefPattern.MatchString(ref):
+		result.Class = UsesRefVersion
+	default:
+		result.Class = UsesRefBranch
+	}
+
+	return result
+}

--- a/pkg/ref_classifier_test.go
+++ b/pkg/ref_classifier_test.go
@@ -1,0 +1,179 @@
+package pkg
+
+import "testing"
+
+func TestClassifyUsesRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		uses          string
+		expectedClass UsesRefClass
+		expectedPath  string
+		expectedRepo  string
+		expectedRef   string
+	}{
+		{
+			name:          "local action",
+			uses:          "./.github/actions/setup",
+			expectedClass: UsesRefLocal,
+			expectedPath:  "./.github/actions/setup",
+		},
+		{
+			name:          "sha ref",
+			uses:          "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+			expectedClass: UsesRefSHA,
+			expectedPath:  "actions/checkout",
+			expectedRepo:  "actions/checkout",
+			expectedRef:   "8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+		},
+		{
+			name:          "sha ref with subpath",
+			uses:          "owner/repo/path/to/action@0123456789abcdef0123456789abcdef01234567",
+			expectedClass: UsesRefSHA,
+			expectedPath:  "owner/repo/path/to/action",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "0123456789abcdef0123456789abcdef01234567",
+		},
+		{
+			name:          "version ref with v prefix",
+			uses:          "actions/setup-go@v5.0.1",
+			expectedClass: UsesRefVersion,
+			expectedPath:  "actions/setup-go",
+			expectedRepo:  "actions/setup-go",
+			expectedRef:   "v5.0.1",
+		},
+		{
+			name:          "version ref without v prefix",
+			uses:          "actions/setup-go@3.2",
+			expectedClass: UsesRefVersion,
+			expectedPath:  "actions/setup-go",
+			expectedRepo:  "actions/setup-go",
+			expectedRef:   "3.2",
+		},
+		{
+			name:          "branch ref",
+			uses:          "actions/checkout@main",
+			expectedClass: UsesRefBranch,
+			expectedPath:  "actions/checkout",
+			expectedRepo:  "actions/checkout",
+			expectedRef:   "main",
+		},
+		{
+			name:          "branch ref with subpath",
+			uses:          "owner/repo/path/to/action@feature/new-branch",
+			expectedClass: UsesRefBranch,
+			expectedPath:  "owner/repo/path/to/action",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "feature/new-branch",
+		},
+		{
+			name:          "branch ref with dot slash and subpath",
+			uses:          "owner/repo/path/to/action@release/v1.2",
+			expectedClass: UsesRefBranch,
+			expectedPath:  "owner/repo/path/to/action",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "release/v1.2",
+		},
+		{
+			name:          "branch ref with slash underscore hyphen",
+			uses:          "owner/repo/path/to/action@feature/foo_bar-baz",
+			expectedClass: UsesRefBranch,
+			expectedPath:  "owner/repo/path/to/action",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "feature/foo_bar-baz",
+		},
+		{
+			name:          "unsupported docker ref",
+			uses:          "docker://alpine:3.20",
+			expectedClass: UsesRefUnsupported,
+			expectedPath:  "docker://alpine:3.20",
+		},
+		{
+			name:          "unsupported external without at",
+			uses:          "actions/checkout",
+			expectedClass: UsesRefUnsupported,
+			expectedPath:  "actions/checkout",
+			expectedRepo:  "actions/checkout",
+		},
+		{
+			name:          "unsupported external trailing at",
+			uses:          "actions/checkout@",
+			expectedClass: UsesRefUnsupported,
+			expectedPath:  "actions/checkout",
+			expectedRepo:  "actions/checkout",
+		},
+		{
+			name:          "unsupported malformed external",
+			uses:          "actions@v1",
+			expectedClass: UsesRefUnsupported,
+			expectedPath:  "actions",
+			expectedRef:   "v1",
+		},
+		{
+			name:          "version ref with subpath",
+			uses:          "owner/repo/sub-action@v3",
+			expectedClass: UsesRefVersion,
+			expectedPath:  "owner/repo/sub-action",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "v3",
+		},
+		{
+			name:          "version ref major only with v",
+			uses:          "actions/checkout@v4",
+			expectedClass: UsesRefVersion,
+			expectedPath:  "actions/checkout",
+			expectedRepo:  "actions/checkout",
+			expectedRef:   "v4",
+		},
+		{
+			name:          "version ref major only without v",
+			uses:          "actions/checkout@1",
+			expectedClass: UsesRefVersion,
+			expectedPath:  "actions/checkout",
+			expectedRepo:  "actions/checkout",
+			expectedRef:   "1",
+		},
+		{
+			name:          "version ref with subpath and full semver",
+			uses:          "owner/repo/sub-action@v1.2.3",
+			expectedClass: UsesRefVersion,
+			expectedPath:  "owner/repo/sub-action",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "v1.2.3",
+		},
+		{
+			name:          "branch ref with subpath",
+			uses:          "owner/repo/sub-action@main",
+			expectedClass: UsesRefBranch,
+			expectedPath:  "owner/repo/sub-action",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "main",
+		},
+		{
+			name:          "sha ref with subpath deep nested",
+			uses:          "owner/repo/a/b/c@0123456789abcdef0123456789abcdef01234567",
+			expectedClass: UsesRefSHA,
+			expectedPath:  "owner/repo/a/b/c",
+			expectedRepo:  "owner/repo",
+			expectedRef:   "0123456789abcdef0123456789abcdef01234567",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ClassifyUsesRef(tt.uses)
+
+			if result.Class != tt.expectedClass {
+				t.Errorf("ClassifyUsesRef(%q).Class = %q, expected %q", tt.uses, result.Class, tt.expectedClass)
+			}
+			if result.ActionPath != tt.expectedPath {
+				t.Errorf("ClassifyUsesRef(%q).ActionPath = %q, expected %q", tt.uses, result.ActionPath, tt.expectedPath)
+			}
+			if result.BaseRepo != tt.expectedRepo {
+				t.Errorf("ClassifyUsesRef(%q).BaseRepo = %q, expected %q", tt.uses, result.BaseRepo, tt.expectedRepo)
+			}
+			if result.Ref != tt.expectedRef {
+				t.Errorf("ClassifyUsesRef(%q).Ref = %q, expected %q", tt.uses, result.Ref, tt.expectedRef)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `--latest` flag to the `workflows` command, allowing users to pin GitHub Actions in workflow files to the latest stable release, and updates the documentation and implementation accordingly. It also upgrades several GitHub Actions and CI dependencies to their latest major versions, improves workflow file processing logic for better reliability, and enhances test coverage and maintainability.

**Major new feature:**

* Added a `--latest` flag to the `workflows` command, enabling resolution of external action references to the latest stable release before pinning. The README is updated with usage details and practical examples. [[1]](diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR28) [[2]](diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R108)

**Enhancements to action pinning logic:**

* Improved the logic in `processActionsYaml` to support the new `--latest` mode, utilize a resolution cache for efficiency, and robustly replace old version comments when re-pinning actions. [[1]](diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR72-R74) [[2]](diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL93-R96) [[3]](diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bL110-R129) [[4]](diffhunk://#diff-71590cef3e3d133ae73992f3dc77af3470bedfe6a4ccf6cc7d34ebf5e4b7e50bR149-R160)
* Refactored action resolution into reusable functions and introduced a warning mechanism for resolution failures to improve maintainability and error messaging.

**Dependency and workflow updates:**

* Upgraded versions of key GitHub Actions (such as `actions/checkout`, `actions/setup-go`, `github/super-linter/slim`, and others) in workflow files for CI, linter, and release processes. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL18-R24) [[2]](diffhunk://#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L42-R48) [[3]](diffhunk://#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L57-R62) [[4]](diffhunk://#diff-6942706d71f70018c8f087d0a45e76d7192106920b2b3892cb86f70443ec2078L16-R16) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L14-R15)

**Code quality and testing improvements:**

* Refactored and improved tests in `cmd/workflows_test.go` for better reliability and coverage, including logger setup and file handling. [[1]](diffhunk://#diff-4d2146ac99cf7b728f8adcb45a11f2404b7fdf0100bf9fecdcfe471dfe16e960R4-L11) [[2]](diffhunk://#diff-4d2146ac99cf7b728f8adcb45a11f2404b7fdf0100bf9fecdcfe471dfe16e960L30) [[3]](diffhunk://#diff-4d2146ac99cf7b728f8adcb45a11f2404b7fdf0100bf9fecdcfe471dfe16e960L72-R88)

**Minor fixes:**

* Fixed usage of `ExtractOwnerRepo` to correctly handle its return values. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL107-R107) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL162-R162)